### PR TITLE
Fix for empty categories string

### DIFF
--- a/obamenu.py
+++ b/obamenu.py
@@ -178,7 +178,7 @@ def process_dtfile(dtf,  catDict):  # process this file & extract relevant info
                 continue
             this.add_type(eqi[1])
         elif eqi[0] == "Categories":
-            if eqi[1][-1] == ';':
+            if eqi[1] and eqi[1][-1] == ';':
                 eqi[1] = eqi[1][0:-1]
             cats = []
             # DEBUG


### PR DESCRIPTION
You'll get an index out of range error if you try to -1 an empty string. This checks for an empty or none before trying to pull the last character.